### PR TITLE
useGranularMemo return T instead of unknown

### DIFF
--- a/src/hooks/useGranularMemo.ts
+++ b/src/hooks/useGranularMemo.ts
@@ -5,6 +5,6 @@ const useGranularMemo = <T>(
   factory: () => T,
   primaryDeps: DependencyList,
   secondaryDeps: DependencyList
-) => useGranularHook(useMemo, factory, primaryDeps, secondaryDeps);
+) => useGranularHook(useMemo, factory, primaryDeps, secondaryDeps) as T;
 
 export default useGranularMemo;


### PR DESCRIPTION
Cast the return type of `useGranularMemo `to `T` instead of defaulting to `unknown`. Right now, anyone using the hook in strict mode needs to do the casting for every use.